### PR TITLE
feat: redesenhar UI com tema Material 3 centralizado

### DIFF
--- a/docs/redesign-material3.md
+++ b/docs/redesign-material3.md
@@ -1,0 +1,117 @@
+# Redesign UI — Tema Material 3
+
+Branch: `feat/material3-theme-redesign` · PR: https://github.com/Alessandro-Franca01/padaria_app/pull/new/feat/material3-theme-redesign
+
+## O que foi feito
+
+### Tema centralizado
+- Criado `lib/theme/app_theme.dart`:
+  - `ColorScheme.fromSeed` com semente âmbar/caramelo (`AppColors.seed = 0xFFB5651D`), Material 3 (`useMaterial3: true`).
+  - Superfícies neutras e claras (visual "app de delivery moderno"), em vez do creme/marrom pesado.
+  - Temas padronizados para: `AppBarTheme`, `CardTheme`, `FilledButtonTheme`, `ElevatedButtonTheme`, `OutlinedButtonTheme`, `TextButtonTheme`, `InputDecorationTheme`, `ChipTheme`, `NavigationBarTheme`, `SnackBarTheme`, `DividerTheme`.
+  - Tokens auxiliares: `AppColors.success/successContainer/warning/warningContainer` (estados semânticos fora do `ColorScheme` padrão) e `AppRadii.sm/md/lg`.
+- `lib/main.dart`: removido o tema inline Material 2 (`primarySwatch: Colors.brown`); aplicado `AppTheme.light`; `debugShowCheckedModeBanner: false`.
+
+### Telas atualizadas (todas as 15)
+Splash, Login, Register, Home, Products, Product Detail, Cart, Checkout, Orders, Order Detail, Order Confirmation, Plans, Plan Details, Subscription Plans List, Chat, Profile.
+
+Mudanças recorrentes em quase todas:
+- Removidas cores cravadas (`Colors.brown[...]`, `Colors.grey[...]`, `Colors.green`, `Colors.red`, `Colors.orange` soltos) em favor de `Theme.of(context).colorScheme.*` ou `AppColors.*`.
+- `Card` com `elevation`/`shape` manuais → herdando o `CardTheme` do tema.
+- `ElevatedButton` com `style` manual → `FilledButton` / `OutlinedButton` do tema (menos código, visual consistente).
+- `AppBar` com `backgroundColor: Colors.brown` removido (herda do tema).
+
+### Bugs corrigidos
+- **Botões com `backgroundColor: Colors.white30`** (ficavam translúcidos/quase invisíveis) — estavam em pontos críticos de conversão:
+  - Home → "Ver Todos os Produtos"
+  - Carrinho → "Finalizar Compra"
+  - Checkout → "Finalizar Pedido"
+  - Plans → "Escolher" (horário) e "Usar endereço do perfil"
+- Order Confirmation: botão "Ver Meus Pedidos" tinha texto âmbar sobre fundo marrom (contraste ruim) → agora `FilledButton` padrão do tema.
+
+### Navegação
+- `BottomNavigationBar` (Material 2, cores cravadas, badges manuais via `Stack`/`Positioned`) → **`NavigationBar`** (Material 3) com **`Badge`** nativo para contadores de pedidos ativos e itens do carrinho.
+
+### Componentes específicos
+- **Login**: tela reorganizada (ícone em círculo com `primaryContainer`, hierarquia de título/subtítulo), botão de entrar com spinner usando `colorScheme.onPrimary`.
+- **Home**: seções duplicadas de título removidas (ex.: "Nossas Especialidades" + "Categorias" viraram uma seção só), carrossel de destaques ganhou overlay de gradiente + título sobre a imagem.
+- **Chat**: bolhas de mensagem com cauda assimétrica (estilo app de mensagens), campo de envio com `SafeArea`, botão de enviar `IconButton.filled`.
+- **Cart**: item card com controles de quantidade `IconButton.filledTonal`/`filled`, empty state redesenhado com ícone em círculo.
+- **Checkout**: os 6 cards de seção (resumo, endereço, data/hora, recorrência, pagamento, fidelidade, observações) padronizados; `showDatePicker`/`showTimePicker` não sobrescrevem mais o tema com marrom cravado — herdam o `AppTheme.light`.
+- **Profile**: avatar com `primaryContainer`, botão salvar `FilledButton.icon`.
+
+## O que ainda precisa ser testado
+
+> Nada foi testado em dispositivo/emulador ainda além da checagem visual feita pelo usuário. Este checklist serve para a próxima rodada de testes manuais.
+
+### Fluxo de autenticação
+- [ ] Login com credenciais válidas → navega para Home
+- [ ] Login com credenciais inválidas → SnackBar de erro aparece com a cor certa (`colorScheme.error`)
+- [ ] Cadastro (Register): validação de campos, aceite de termos obrigatório, SnackBar de erro/sucesso
+- [ ] Logout a partir do Profile → volta para Login
+
+### Navegação principal (Home)
+- [ ] `NavigationBar` (Início/Planos/Pedidos/Carrinho) troca de aba corretamente
+- [ ] Badge de pedidos ativos aparece/some conforme pedidos mudam de status
+- [ ] Badge do carrinho aparece/some conforme itens são adicionados/removidos
+- [ ] Carrossel de destaques rola automaticamente e o texto sobre gradiente está legível
+- [ ] Botão "Ver Todos os Produtos" navega e está visualmente sólido (bug do `white30` corrigido)
+- [ ] Grid de categorias navega para Products filtrado
+
+### Produtos
+- [ ] Listagem carrega, filtro por categoria (chips) funciona
+- [ ] Busca (search delegate) retorna sugestões e resultados
+- [ ] Card de produto: botão de adicionar ao carrinho funciona quando disponível e fica desabilitado quando indisponível
+- [ ] Detalhe do produto: seletor de quantidade, campo de observações, "Adicionar ao Carrinho" e "Ver Carrinho" (com badge) funcionam
+
+### Carrinho
+- [ ] Item: alterar quantidade, remover item, adicionar/editar observações
+- [ ] Empty state aparece quando carrinho vazio, botão "Continuar Comprando" navega
+- [ ] "Limpar carrinho" (diálogo de confirmação) funciona
+- [ ] Botão "Finalizar Compra" **visualmente sólido** (não translúcido) e bloqueia se não autenticado
+
+### Checkout
+- [ ] Resumo do pedido reflete itens do carrinho
+- [ ] Endereço: alternar entre "usar cadastrado" e digitar novo
+- [ ] Seleção de data e hora de entrega (verificar se o `DatePicker`/`TimePicker` está com as cores do tema, não mais marrom cravado)
+- [ ] Pedido recorrente: ativar switch, selecionar dias da semana
+- [ ] Forma de pagamento: seleção via radio
+- [ ] Pontos de fidelidade exibidos corretamente
+- [ ] Validações: SnackBars de aviso (data/hora, dias recorrentes, endereço) aparecem com a cor `AppColors.warning`
+- [ ] Botão "Finalizar Pedido" **visualmente sólido**, estado de loading, navega para confirmação
+
+### Confirmação e Pedidos
+- [ ] Tela de confirmação exibe dados corretos do pedido e pontos ganhos
+- [ ] Botões "Ver Meus Pedidos" e "Voltar ao Início" funcionam
+- [ ] Aba Pedidos: tabs "Ativos"/"Histórico" filtram corretamente
+- [ ] Pull-to-refresh atualiza a lista
+- [ ] Card de pedido: cores de status (`_getStatusColor`) continuam corretas para todos os status
+- [ ] Detalhe do pedido: cancelar pedido (diálogo + SnackBar de sucesso/erro), reordenar (pedidos concluídos), contato/suporte (diálogo)
+
+### Assinaturas/Planos
+- [ ] Lista de planos: catálogo de templates (scroll horizontal) e "Meus Planos"
+- [ ] Criar plano: selecionar template, escolher produtos e quantidades, dias da semana, horário (`TimePicker` com tema correto), endereço (usar do perfil ou digitar)
+- [ ] Switch "Plano ativo" funciona sem cor cravada
+- [ ] Resumo do plano atualiza em tempo real
+- [ ] Salvar plano: loading, navegação para detalhes, SnackBar de erro em caso de falha
+- [ ] Editar plano existente: campos pré-preenchidos corretamente
+- [ ] Detalhes do plano: botão de editar (ícone) e "Voltar"
+
+### Chat
+- [ ] Lista de conversas/mensagens carrega
+- [ ] Enviar mensagem (botão e `onSubmitted` do teclado)
+- [ ] Bolhas de mensagem: cor correta para usuário vs. padaria, texto legível
+- [ ] Refresh manual (ícone) e pull-to-refresh
+
+### Perfil
+- [ ] Dados do usuário carregam nos campos (nome, telefone, endereço)
+- [ ] Validação de campos obrigatórios
+- [ ] Salvar alterações: loading, SnackBar de sucesso/erro
+- [ ] Avatar com iniciais e pontos de fidelidade exibidos
+
+### Geral / regressão visual
+- [ ] Nenhum texto com contraste ruim (branco sobre claro, âmbar sobre marrom, etc.)
+- [ ] Nenhum botão com aparência translúcida/"lavada"
+- [ ] Consistência de cantos arredondados (`AppRadii`) entre cards, botões e inputs
+- [ ] Testar em pelo menos um dispositivo Android real ou emulador com tema claro do sistema
+- [ ] Rodar `flutter analyze` para conferir se não há erros novos (os avisos de `const` são pré-existentes e não bloqueiam)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'services/loyalty_service.dart';
 import 'services/order_service.dart';
 import 'services/chat_service.dart';
 import 'services/subscription_service.dart';
+import 'theme/app_theme.dart';
 
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
@@ -47,19 +48,8 @@ class MyApp extends StatelessWidget {
           '/login': (context) => LoginScreen(),
         },
         title: 'Padaria App',
-        theme: ThemeData(
-          primarySwatch: Colors.brown,
-          colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.brown).copyWith(
-            secondary: Colors.orangeAccent,
-          ),
-          fontFamily: 'Roboto',
-          textTheme: TextTheme(
-            displayLarge: TextStyle(fontSize: 24.0, fontWeight: FontWeight.bold, color: Colors.brown),
-            displayMedium: TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold, color: Colors.brown[700]),
-            bodyLarge: TextStyle(fontSize: 16.0, color: Colors.black87),
-            bodyMedium: TextStyle(fontSize: 14.0, color: Colors.black54),
-          ),
-        ),
+        debugShowCheckedModeBanner: false,
+        theme: AppTheme.light,
         home: SplashScreen(), // Set SplashScreen as the initial route
       ),
     );

--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../models/cart_item.dart';
 import '../services/cart_service.dart';
 import '../services/auth_service.dart';
+import '../theme/app_theme.dart';
 import 'checkout_screen.dart';
 import 'products_screen.dart';
 
@@ -17,7 +18,6 @@ class _CartScreenState extends State<CartScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Carrinho de Compras'),
-        backgroundColor: Colors.brown,
         actions: [
           Consumer<CartService>(
             builder: (context, cartService, child) {
@@ -61,7 +61,7 @@ class _CartScreenState extends State<CartScreen> {
                           SnackBar(
                             content: Text('${cartItem.product.name} removido do carrinho'),
                             duration: Duration(seconds: 2),
-                            backgroundColor: Colors.red,
+                            backgroundColor: Theme.of(context).colorScheme.error,
                           ),
                         );
                       },
@@ -81,57 +81,61 @@ class _CartScreenState extends State<CartScreen> {
   }
 
   Widget _buildEmptyCart(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.shopping_cart_outlined,
-            size: 100,
-            color: Colors.grey[400],
-          ),
-          SizedBox(height: 24),
-          Text(
-            'Seu carrinho está vazio',
-            style: TextStyle(
-              fontSize: 24,
-              fontWeight: FontWeight.bold,
-              color: Colors.grey[600],
-            ),
-          ),
-          SizedBox(height: 16),
-          Text(
-            'Adicione alguns produtos deliciosos!',
-            style: TextStyle(
-              fontSize: 16,
-              color: Colors.grey[500],
-            ),
-            textAlign: TextAlign.center,
-          ),
-          SizedBox(height: 32),
-          ElevatedButton.icon(
-            onPressed: () {
-              final navigator = Navigator.of(context);
-              if (navigator.canPop()) {
-                navigator.pop();
-              }
-              navigator.push(
-                MaterialPageRoute(
-                  builder: (context) => ProductsScreen(),
-                ),
-              );
-            },
-            icon: Icon(Icons.shopping_bag),
-            label: Text('Continuar Comprando'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.white30,
-              padding: EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
+      child: Padding(
+        padding: EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              padding: EdgeInsets.all(28),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.shopping_cart_outlined,
+                size: 64,
+                color: colorScheme.onSurfaceVariant,
               ),
             ),
-          ),
-        ],
+            SizedBox(height: 24),
+            Text(
+              'Seu carrinho está vazio',
+              style: TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.w700,
+                color: colorScheme.onSurface,
+              ),
+            ),
+            SizedBox(height: 8),
+            Text(
+              'Adicione alguns produtos deliciosos!',
+              style: TextStyle(
+                fontSize: 15,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: 28),
+            FilledButton.icon(
+              onPressed: () {
+                final navigator = Navigator.of(context);
+                if (navigator.canPop()) {
+                  navigator.pop();
+                }
+                navigator.push(
+                  MaterialPageRoute(
+                    builder: (context) => ProductsScreen(),
+                  ),
+                );
+              },
+              icon: Icon(Icons.shopping_bag_outlined),
+              label: Text('Continuar Comprando'),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -180,50 +184,37 @@ class _CartScreenState extends State<CartScreen> {
                 style: TextStyle(
                   fontSize: 20,
                   fontWeight: FontWeight.bold,
-                  color: Colors.brown[700],
+                  color: Theme.of(context).colorScheme.primary,
                 ),
               ),
             ],
           ),
           SizedBox(height: 16),
-          SizedBox(
-            width: double.infinity,
-            height: 50,
-            child: Consumer<AuthService>(
-              builder: (context, authService, child) {
-                return ElevatedButton.icon(
-                  onPressed: () {
-                    if (!authService.isAuthenticated) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('Faça login para finalizar a compra'),
-                          backgroundColor: Colors.orange,
-                        ),
-                      );
-                      return;
-                    }
-
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => CheckoutScreen(),
+          Consumer<AuthService>(
+            builder: (context, authService, child) {
+              return FilledButton.icon(
+                onPressed: () {
+                  if (!authService.isAuthenticated) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('Faça login para finalizar a compra'),
+                        backgroundColor: AppColors.warning,
                       ),
                     );
-                  },
-                  icon: Icon(Icons.payment),
-                  label: Text(
-                    'Finalizar Compra',
-                    style: TextStyle(fontSize: 18),
-                  ),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.white30,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10),
+                    return;
+                  }
+
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => CheckoutScreen(),
                     ),
-                  ),
-                );
-              },
-            ),
+                  );
+                },
+                icon: Icon(Icons.payment),
+                label: Text('Finalizar Compra'),
+              );
+            },
           ),
         ],
       ),
@@ -251,7 +242,7 @@ class _CartScreenState extends State<CartScreen> {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
                     content: Text('Carrinho limpo'),
-                    backgroundColor: Colors.green,
+                    backgroundColor: AppColors.success,
                   ),
                 );
               },
@@ -294,10 +285,9 @@ class _CartItemCardState extends State<CartItemCard> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Card(
       margin: EdgeInsets.only(bottom: 12),
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(12),
         child: Column(
@@ -310,12 +300,12 @@ class _CartItemCardState extends State<CartItemCard> {
                   width: 80,
                   height: 80,
                   decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(8),
-                    color: Colors.grey[200],
+                    borderRadius: BorderRadius.circular(10),
+                    color: colorScheme.surfaceContainerHighest,
                   ),
                   child: widget.cartItem.product.imageUrl.startsWith('assets/')
                       ? ClipRRect(
-                    borderRadius: BorderRadius.circular(8),
+                    borderRadius: BorderRadius.circular(10),
                     child: Image.asset(
                       widget.cartItem.product.imageUrl,
                       fit: BoxFit.cover,
@@ -323,7 +313,7 @@ class _CartItemCardState extends State<CartItemCard> {
                           Icon(Icons.image_not_supported),
                     ),
                   )
-                      : Icon(Icons.fastfood, color: Colors.brown),
+                      : Icon(Icons.fastfood, color: colorScheme.primary),
                 ),
 
                 SizedBox(width: 12),
@@ -345,7 +335,7 @@ class _CartItemCardState extends State<CartItemCard> {
                         'R\$ ${widget.cartItem.product.price.toStringAsFixed(
                             2)} cada',
                         style: TextStyle(
-                          color: Colors.grey[600],
+                          color: colorScheme.onSurfaceVariant,
                           fontSize: 14,
                         ),
                       ),
@@ -353,23 +343,22 @@ class _CartItemCardState extends State<CartItemCard> {
                       Row(
                         children: [
                           // Controles de quantidade
-                          IconButton(
+                          IconButton.filledTonal(
                             onPressed: widget.cartItem.quantity > 1 ? () {
                               widget.onUpdateQuantity(
                                   widget.cartItem.quantity - 1);
                             } : null,
                             icon: Icon(Icons.remove),
-                            style: IconButton.styleFrom(
-                              backgroundColor: Colors.grey[200],
-                              minimumSize: Size(32, 32),
-                            ),
+                            constraints: BoxConstraints.tightFor(width: 36, height: 36),
+                            padding: EdgeInsets.zero,
                           ),
                           Container(
-                            width: 50,
-                            height: 32,
+                            width: 44,
+                            height: 36,
+                            margin: EdgeInsets.symmetric(horizontal: 6),
                             decoration: BoxDecoration(
-                              border: Border.all(color: Colors.grey[300]!),
-                              borderRadius: BorderRadius.circular(4),
+                              border: Border.all(color: colorScheme.outlineVariant),
+                              borderRadius: BorderRadius.circular(8),
                             ),
                             child: Center(
                               child: Text(
@@ -378,16 +367,14 @@ class _CartItemCardState extends State<CartItemCard> {
                               ),
                             ),
                           ),
-                          IconButton(
+                          IconButton.filled(
                             onPressed: () {
                               widget.onUpdateQuantity(
                                   widget.cartItem.quantity + 1);
                             },
                             icon: Icon(Icons.add),
-                            style: IconButton.styleFrom(
-                              backgroundColor: Colors.brown[200],
-                              minimumSize: Size(32, 32),
-                            ),
+                            constraints: BoxConstraints.tightFor(width: 36, height: 36),
+                            padding: EdgeInsets.zero,
                           ),
                           Spacer(),
                           Text(
@@ -396,7 +383,7 @@ class _CartItemCardState extends State<CartItemCard> {
                             style: TextStyle(
                               fontSize: 16,
                               fontWeight: FontWeight.bold,
-                              color: Colors.brown[700],
+                              color: colorScheme.primary,
                             ),
                           ),
                         ],
@@ -408,8 +395,8 @@ class _CartItemCardState extends State<CartItemCard> {
                 // Botão de remover
                 IconButton(
                   onPressed: widget.onRemove,
-                  icon: Icon(Icons.delete),
-                  color: Colors.red,
+                  icon: Icon(Icons.delete_outline),
+                  color: colorScheme.error,
                 ),
               ],
             ),
@@ -420,9 +407,9 @@ class _CartItemCardState extends State<CartItemCard> {
               Container(
                 width: double.infinity,
                 margin: EdgeInsets.only(top: 12),
-                padding: EdgeInsets.all(8),
+                padding: EdgeInsets.all(10),
                 decoration: BoxDecoration(
-                  color: Colors.grey[100],
+                  color: colorScheme.surfaceContainerHighest.withOpacity(0.5),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Column(
@@ -433,7 +420,7 @@ class _CartItemCardState extends State<CartItemCard> {
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
                         fontSize: 12,
-                        color: Colors.grey[600],
+                        color: colorScheme.onSurfaceVariant,
                       ),
                     ),
                     SizedBox(height: 4),
@@ -464,7 +451,6 @@ class _CartItemCardState extends State<CartItemCard> {
                     style: TextStyle(fontSize: 12),
                   ),
                   style: TextButton.styleFrom(
-                    foregroundColor: Colors.brown[600],
                     padding: EdgeInsets.symmetric(horizontal: 8),
                   ),
                 ),
@@ -502,7 +488,7 @@ class _CartItemCardState extends State<CartItemCard> {
                           child: Text('Cancelar'),
                         ),
                         SizedBox(width: 8),
-                        ElevatedButton(
+                        FilledButton(
                           onPressed: () {
                             widget.onUpdateNotes(_notesController.text
                                 .trim()
@@ -513,10 +499,10 @@ class _CartItemCardState extends State<CartItemCard> {
                               _isExpanded = false;
                             });
                           },
-                          child: Text('Salvar'),
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.brown[700],
+                          style: FilledButton.styleFrom(
+                            minimumSize: Size(0, 40),
                           ),
+                          child: Text('Salvar'),
                         ),
                       ],
                     ),

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -42,7 +42,7 @@ class _ChatScreenState extends State<ChatScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(e is ApiException ? e.message : 'Não foi possível enviar a mensagem.'),
-          backgroundColor: Colors.red,
+          backgroundColor: Theme.of(context).colorScheme.error,
         ),
       );
     }
@@ -50,26 +50,38 @@ class _ChatScreenState extends State<ChatScreen> {
 
   Widget _buildMessage(ChatMessage message) {
     final isUser = message.sender == MessageSender.user;
+    final colorScheme = Theme.of(context).colorScheme;
+    final bubbleColor = isUser ? colorScheme.primary : colorScheme.surfaceContainerHighest;
+    final textColor = isUser ? colorScheme.onPrimary : colorScheme.onSurface;
+    final timeColor = isUser
+        ? colorScheme.onPrimary.withOpacity(0.7)
+        : colorScheme.onSurfaceVariant;
     return Align(
       alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
       child: Container(
-        margin: EdgeInsets.symmetric(vertical: 6, horizontal: 12),
-        padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+        constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.78),
+        margin: EdgeInsets.symmetric(vertical: 5, horizontal: 12),
+        padding: EdgeInsets.symmetric(vertical: 10, horizontal: 14),
         decoration: BoxDecoration(
-          color: isUser ? Colors.brown[300] : Colors.grey[300],
-          borderRadius: BorderRadius.circular(12),
+          color: bubbleColor,
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(16),
+            topRight: Radius.circular(16),
+            bottomLeft: Radius.circular(isUser ? 16 : 4),
+            bottomRight: Radius.circular(isUser ? 4 : 16),
+          ),
         ),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               message.content,
-              style: TextStyle(color: Colors.black87),
+              style: TextStyle(color: textColor),
             ),
             SizedBox(height: 4),
             Text(
               message.formattedTime,
-              style: TextStyle(fontSize: 10, color: Colors.black54),
+              style: TextStyle(fontSize: 10, color: timeColor),
             ),
           ],
         ),
@@ -82,7 +94,6 @@ class _ChatScreenState extends State<ChatScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Chat com a Padaria'),
-        backgroundColor: Colors.brown,
         actions: [
           IconButton(
             icon: Icon(Icons.refresh),
@@ -111,30 +122,34 @@ class _ChatScreenState extends State<ChatScreen> {
           ),
           Container(
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: Theme.of(context).colorScheme.surface,
               boxShadow: [
-                BoxShadow(color: Colors.black12, blurRadius: 4, offset: Offset(0, -2)),
+                BoxShadow(color: Colors.black.withOpacity(0.06), blurRadius: 4, offset: Offset(0, -2)),
               ],
             ),
-            padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _controller,
-                    decoration: InputDecoration(
-                      hintText: 'Digite sua mensagem',
-                      border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
-                      contentPadding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            padding: EdgeInsets.fromLTRB(12, 8, 8, 8),
+            child: SafeArea(
+              top: false,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _controller,
+                      textInputAction: TextInputAction.send,
+                      onSubmitted: (_) => _sendMessage(),
+                      decoration: InputDecoration(
+                        hintText: 'Digite sua mensagem',
+                        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                      ),
                     ),
                   ),
-                ),
-                SizedBox(width: 8),
-                IconButton(
-                  icon: Icon(Icons.send, color: Colors.brown),
-                  onPressed: _sendMessage,
-                ),
-              ],
+                  SizedBox(width: 8),
+                  IconButton.filled(
+                    icon: Icon(Icons.send),
+                    onPressed: _sendMessage,
+                  ),
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/screens/checkout_screen.dart
+++ b/lib/screens/checkout_screen.dart
@@ -5,6 +5,7 @@ import '../services/auth_service.dart';
 import '../services/loyalty_service.dart';
 import '../services/order_service.dart';
 import '../services/api_client.dart';
+import '../theme/app_theme.dart';
 import 'order_confirmation_screen.dart';
 
 class CheckoutScreen extends StatefulWidget {
@@ -66,7 +67,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Finalizar Compra'),
-        backgroundColor: Colors.brown,
       ),
       body: Consumer3<CartService, AuthService, LoyaltyService>(
         builder: (context, cartService, authService, loyaltyService, child) {
@@ -125,8 +125,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
 
   Widget _buildOrderSummary(CartService cartService) {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -168,7 +166,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                   style: TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
-                    color: Colors.brown[700],
+                    color: Theme.of(context).colorScheme.primary,
                   ),
                 ),
               ],
@@ -181,8 +179,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
 
   Widget _buildDeliveryAddress(AuthService authService) {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -239,8 +235,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
 
   Widget _buildDeliveryDateTime() {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -265,10 +259,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                           ? '${_selectedDeliveryDate!.day}/${_selectedDeliveryDate!.month}/${_selectedDeliveryDate!.year}'
                           : 'Selecionar Data',
                     ),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: Colors.brown[700],
-                      side: BorderSide(color: Colors.brown[300]!),
-                    ),
                   ),
                 ),
                 SizedBox(width: 12),
@@ -280,10 +270,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                       _selectedDeliveryTime != null
                           ? '${_selectedDeliveryTime!.hour}:${_selectedDeliveryTime!.minute.toString().padLeft(2, '0')}'
                           : 'Selecionar Hora',
-                    ),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: Colors.brown[700],
-                      side: BorderSide(color: Colors.brown[300]!),
                     ),
                   ),
                 ),
@@ -297,8 +283,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
 
   Widget _buildRecurringOrder() {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -315,7 +299,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
             Text(
               'Receba seus produtos favoritos automaticamente nos dias selecionados',
               style: TextStyle(
-                color: Colors.grey[600],
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
                 fontSize: 14,
               ),
             ),
@@ -331,7 +315,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                   }
                 });
               },
-              activeColor: Colors.brown[700],
+              contentPadding: EdgeInsets.zero,
             ),
             if (_isRecurring) ...[
               SizedBox(height: 12),
@@ -359,7 +343,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                           }
                         });
                       },
-                      selectedColor: Colors.brown[300],
                     ),
                   );
                 }).toList(),
@@ -373,8 +356,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
 
   Widget _buildPaymentMethod() {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -398,7 +379,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                     _selectedPaymentMethod = value!;
                   });
                 },
-                activeColor: Colors.brown[700],
+                contentPadding: EdgeInsets.zero,
               );
             }).toList(),
           ],
@@ -409,8 +390,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
 
   Widget _buildLoyaltyProgram(LoyaltyService loyaltyService, double totalAmount) {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -435,8 +414,8 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
             Text(
               'Com esta compra você ganhará: ${(totalAmount / 5).round()} pontos',
               style: TextStyle(
-                color: Colors.green[700],
-                fontWeight: FontWeight.w500,
+                color: AppColors.success,
+                fontWeight: FontWeight.w600,
               ),
             ),
           ],
@@ -447,8 +426,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
 
   Widget _buildObservations() {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -479,29 +456,21 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
   }
 
   Widget _buildFinishButton(CartService cartService, AuthService authService, LoyaltyService loyaltyService) {
-    return SizedBox(
-      width: double.infinity,
-      height: 50,
-      child: ElevatedButton.icon(
-        onPressed: _isSubmitting ? null : () => _finishOrder(cartService, authService, loyaltyService),
-        icon: _isSubmitting
-            ? SizedBox(
-                width: 18,
-                height: 18,
-                child: CircularProgressIndicator(strokeWidth: 2, color: Colors.brown),
-              )
-            : Icon(Icons.check_circle),
-        label: Text(
-          _isSubmitting ? 'Enviando...' : 'Finalizar Pedido',
-          style: TextStyle(fontSize: 18),
-        ),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.white30,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10),
-          ),
-        ),
-      ),
+    return FilledButton.icon(
+      onPressed: _isSubmitting ? null : () => _finishOrder(cartService, authService, loyaltyService),
+      icon: _isSubmitting
+          ? SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(
+                  Theme.of(context).colorScheme.onPrimary,
+                ),
+              ),
+            )
+          : Icon(Icons.check_circle),
+      label: Text(_isSubmitting ? 'Enviando...' : 'Finalizar Pedido'),
     );
   }
 
@@ -511,16 +480,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
       initialDate: DateTime.now().add(Duration(days: 1)),
       firstDate: DateTime.now(),
       lastDate: DateTime.now().add(Duration(days: 30)),
-      builder: (context, child) {
-        return Theme(
-          data: Theme.of(context).copyWith(
-            colorScheme: ColorScheme.light(
-              primary: Colors.brown[700]!,
-            ),
-          ),
-          child: child!,
-        );
-      },
     );
 
     if (picked != null) {
@@ -534,16 +493,6 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
     final TimeOfDay? picked = await showTimePicker(
       context: context,
       initialTime: TimeOfDay(hour: 8, minute: 0),
-      builder: (context, child) {
-        return Theme(
-          data: Theme.of(context).copyWith(
-            colorScheme: ColorScheme.light(
-              primary: Colors.brown[700]!,
-            ),
-          ),
-          child: child!,
-        );
-      },
     );
 
     if (picked != null) {
@@ -562,7 +511,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Por favor, selecione data e hora de entrega'),
-          backgroundColor: Colors.orange,
+          backgroundColor: AppColors.warning,
         ),
       );
       return;
@@ -572,7 +521,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Selecione pelo menos um dia para o pedido recorrente'),
-          backgroundColor: Colors.orange,
+          backgroundColor: AppColors.warning,
         ),
       );
       return;
@@ -615,7 +564,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(e is ApiException ? e.message : 'Não foi possível finalizar o pedido. Tente novamente.'),
-          backgroundColor: Colors.red,
+          backgroundColor: Theme.of(context).colorScheme.error,
         ),
       );
     } finally {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -13,6 +13,7 @@ import 'package:padaria_app/models/order.dart';
 import 'chat_screen.dart';
 import 'profile_screen.dart';
 import 'subscription_plans_list_screen.dart';
+import '../theme/app_theme.dart';
 
 class HomeScreen extends StatefulWidget {
   @override
@@ -30,11 +31,20 @@ class _HomeScreenState extends State<HomeScreen> {
     _pageController.jumpToPage(index);
   }
 
+  /// Título de seção padronizado da Home.
+  Widget _sectionTitle(BuildContext context, String text) {
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+    );
+  }
+
   Widget _buildDiscountItem(DiscountItem discount) {
     return Expanded(
       child: GestureDetector(
         onTap: () {
-          print('Tag selecionada: ${discount.description}');
           // Navegar para produtos com desconto
           Navigator.push(
             context,
@@ -44,10 +54,6 @@ class _HomeScreenState extends State<HomeScreen> {
           );
         },
         child: Card(
-          elevation: 2,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
           child: Padding(
             padding: EdgeInsets.all(8),
             child: Column(
@@ -62,12 +68,12 @@ class _HomeScreenState extends State<HomeScreen> {
                     fit: BoxFit.cover,
                   ),
                 ),
-                SizedBox(height: 4),
+                SizedBox(height: 6),
                 Text(
                   discount.description,
                   style: TextStyle(
                     fontSize: 12,
-                    color: Colors.grey[600],
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
                   textAlign: TextAlign.center,
                 ),
@@ -84,10 +90,9 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Padaria App'),
-        backgroundColor: Colors.brown,
         actions: [
           IconButton(
-            icon: Icon(Icons.chat),
+            icon: Icon(Icons.chat_bubble_outline),
             onPressed: () {
               Navigator.push(
                 context,
@@ -170,58 +175,39 @@ class _HomeScreenState extends State<HomeScreen> {
               children: [
                 // Header
                 Text(
-                  'Bem-vindo!',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.brown,
-                  ),
+                  'Bem-vindo! 👋',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
                 ),
-                SizedBox(height: 8),
+                SizedBox(height: 6),
                 Text(
                   'Descubra os principais produtos e ofertas!',
                   style: TextStyle(
-                    fontSize: 16,
-                    color: Colors.grey[600],
+                    fontSize: 15,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
                 ),
-                SizedBox(height: 16),
+                SizedBox(height: 20),
 
                 // Botão Ver Todos os Produtos
-                SizedBox(
-                  width: double.infinity,
-                  height: 50,
-                  child: ElevatedButton.icon(
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => ProductsScreen(),
-                        ),
-                      );
-                    },
-                    icon: Icon(Icons.store),
-                    label: Text('Ver Todos os Produtos'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white30,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10),
+                FilledButton.icon(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ProductsScreen(),
                       ),
-                    ),
-                  ),
+                    );
+                  },
+                  icon: Icon(Icons.storefront_outlined),
+                  label: Text('Ver Todos os Produtos'),
                 ),
 
-                SizedBox(height: 24),
+                SizedBox(height: 28),
 
                 // Seção Destaques
-                Text(
-                  'Destaques',
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.brown,
-                  ),
-                ),
+                _sectionTitle(context, 'Destaques'),
                 SizedBox(height: 12),
                 CarouselSlider.builder(
                   itemCount: carouselItems.length,
@@ -242,28 +228,37 @@ class _HomeScreenState extends State<HomeScreen> {
                         );
                       },
                       child: Card(
-                        elevation: 5,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Column(
+                        child: Stack(
+                          fit: StackFit.expand,
                           children: [
-                            ClipRRect(
-                              borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
-                              child: Image.asset(
-                                carouselItems[index].imagePath,
-                                height: 120,
-                                width: double.infinity,
-                                fit: BoxFit.cover,
+                            Image.asset(
+                              carouselItems[index].imagePath,
+                              fit: BoxFit.cover,
+                            ),
+                            // Gradiente para legibilidade do texto sobre a imagem
+                            DecoratedBox(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  colors: [
+                                    Colors.transparent,
+                                    Colors.black.withOpacity(0.65),
+                                  ],
+                                  stops: const [0.45, 1.0],
+                                ),
                               ),
                             ),
-                            Padding(
-                              padding: EdgeInsets.all(8),
+                            Positioned(
+                              left: 14,
+                              right: 14,
+                              bottom: 12,
                               child: Text(
                                 carouselItems[index].title,
-                                style: TextStyle(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.bold,
+                                style: const TextStyle(
+                                  fontSize: 17,
+                                  fontWeight: FontWeight.w700,
+                                  color: Colors.white,
                                 ),
                               ),
                             ),
@@ -274,203 +269,119 @@ class _HomeScreenState extends State<HomeScreen> {
                   },
                 ),
 
-                SizedBox(height: 24),
-                Divider(),
-                SizedBox(height: 16),
+                SizedBox(height: 28),
 
                 // Seção Promoções
-                Text(
-                  'Promoções Exclusivas do App',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                SizedBox(height: 8),
-                Card(
-                  child: Padding(
-                    padding: EdgeInsets.all(12),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: EdgeInsets.fromLTRB(16, 24, 16, 8),
-                          child: Text(
-                            'Promoções e Descontos',
-                            style: TextStyle(
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                              color: Colors.brown,
-                            ),
-                          ),
+                _sectionTitle(context, 'Promoções e Descontos'),
+                SizedBox(height: 12),
+                SizedBox(
+                  height: 150,
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: (DiscountItems.length / 3).ceil(),
+                    itemBuilder: (context, index) {
+                      return Container(
+                        width: MediaQuery.of(context).size.width * 0.9,
+                        margin: EdgeInsets.only(right: 12),
+                        child: Row(
+                          children: [
+                            _buildDiscountItem(DiscountItems[index * 3]),
+                            SizedBox(width: 12),
+                            if (index * 3 + 1 < DiscountItems.length)
+                              _buildDiscountItem(DiscountItems[index * 3 + 1]),
+                            SizedBox(width: 12),
+                            if (index * 3 + 2 < DiscountItems.length)
+                              _buildDiscountItem(DiscountItems[index * 3 + 2]),
+                          ],
                         ),
-                        SizedBox(
-                          height: 150,
-                          child: ListView.builder(
-                            scrollDirection: Axis.horizontal,
-                            padding: EdgeInsets.symmetric(horizontal: 16),
-                            itemCount: (DiscountItems.length / 3).ceil(),
-                            itemBuilder: (context, index) {
-                              return Container(
-                                width: MediaQuery.of(context).size.width * 0.9,
-                                margin: EdgeInsets.only(right: 12),
-                                child: Row(
-                                  children: [
-                                    _buildDiscountItem(DiscountItems[index * 3]),
-                                    SizedBox(width: 12),
-                                    if (index * 3 + 1 < DiscountItems.length)
-                                      _buildDiscountItem(DiscountItems[index * 3 + 1]),
-                                    SizedBox(width: 12),
-                                    if (index * 3 + 2 < DiscountItems.length)
-                                      _buildDiscountItem(DiscountItems[index * 3 + 2]),
-                                  ],
-                                ),
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
+                      );
+                    },
                   ),
                 ),
 
-                SizedBox(height: 24),
-                Divider(),
-                SizedBox(height: 16),
+                SizedBox(height: 28),
 
                 // Seção Categorias
-                Text(
-                  'Nossas Especialidades',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
+                _sectionTitle(context, 'Nossas Especialidades'),
+                SizedBox(height: 12),
+                GridView.builder(
+                  physics: NeverScrollableScrollPhysics(),
+                  shrinkWrap: true,
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 12,
+                    mainAxisSpacing: 12,
+                    childAspectRatio: 0.8,
                   ),
-                ),
-                SizedBox(height: 8),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Padding(
-                      padding: EdgeInsets.fromLTRB(16, 24, 16, 8),
-                      child: Text(
-                        'Categorias',
-                        style: TextStyle(
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                          color: Colors.brown,
-                        ),
-                      ),
-                    ),
-                    GridView.builder(
-                      physics: NeverScrollableScrollPhysics(),
-                      shrinkWrap: true,
-                      padding: EdgeInsets.all(16),
-                      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                        crossAxisCount: 2,
-                        crossAxisSpacing: 12,
-                        mainAxisSpacing: 12,
-                        childAspectRatio: 0.8,
-                      ),
-                      itemCount: categories.length,
-                      itemBuilder: (context, index) {
-                        return GestureDetector(
-                          onTap: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => ProductsScreen(
-                                  category: categories[index].category,
-                                ),
-                              ),
-                            );
-                          },
-                          child: Card(
-                            elevation: 3,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            child: Column(
-                              children: [
-                                Expanded(
-                                  child: ClipRRect(
-                                    borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
-                                    child: Image.asset(
-                                      categories[index].imagePath,
-                                      height: 120,
-                                      width: double.infinity,
-                                      fit: BoxFit.cover,
-                                    ),
-                                  ),
-                                ),
-                                Padding(
-                                  padding: EdgeInsets.all(8),
-                                  child: Text(
-                                    categories[index].title,
-                                    style: TextStyle(
-                                      fontSize: 16,
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                                    textAlign: TextAlign.center,
-                                  ),
-                                ),
-                              ],
+                  itemCount: categories.length,
+                  itemBuilder: (context, index) {
+                    return GestureDetector(
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => ProductsScreen(
+                              category: categories[index].category,
                             ),
                           ),
                         );
                       },
-                    ),
-                  ],
+                      child: Card(
+                        child: Column(
+                          children: [
+                            Expanded(
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadii.md)),
+                                child: Image.asset(
+                                  categories[index].imagePath,
+                                  width: double.infinity,
+                                  fit: BoxFit.cover,
+                                ),
+                              ),
+                            ),
+                            Padding(
+                              padding: EdgeInsets.all(10),
+                              child: Text(
+                                categories[index].title,
+                                style: TextStyle(
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
                 ),
 
-                SizedBox(height: 24),
-                Divider(),
-                SizedBox(height: 16),
+                SizedBox(height: 28),
 
                 // Seção Assinaturas
-                Text(
-                  'Assinaturas da Padaria',
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.brown,
-                  ),
-                ),
-                SizedBox(height: 8),
+                _sectionTitle(context, 'Assinaturas da Padaria'),
+                SizedBox(height: 6),
                 Text(
                   'Receba seus produtos favoritos toda semana com desconto.',
                   style: TextStyle(
-                    fontSize: 16,
-                    color: Colors.grey[600],
+                    fontSize: 15,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
                   ),
                 ),
                 SizedBox(height: 16),
-                SizedBox(
-                  width: double.infinity,
-                  height: 50,
-                  child: OutlinedButton(
-                    onPressed: () {
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (context) => SubscriptionPlansListScreen(),
-                        ),
-                      );
-                    },
-                    style: OutlinedButton.styleFrom(
-                      side: BorderSide(color: Colors.brown),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10),
+                OutlinedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => SubscriptionPlansListScreen(),
                       ),
-                    ),
-                    child: Text(
-                      'Ver todos os planos',
-                      style: TextStyle(
-                        color: Colors.brown,
-                        fontSize: 16,
-                      ),
-                    ),
-                  ),
+                    );
+                  },
+                  child: Text('Ver todos os planos'),
                 ),
+                SizedBox(height: 8),
               ],
             ),
           ),
@@ -484,23 +395,21 @@ class _HomeScreenState extends State<HomeScreen> {
           CartScreen(),
         ],
       ),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _selectedIndex,
-        onTap: _onItemTapped,
-        backgroundColor: Colors.brown,
-        selectedItemColor: Colors.white,
-        unselectedItemColor: Colors.white70,
-        type: BottomNavigationBarType.fixed,
-        items: [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.home),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: _onItemTapped,
+        destinations: [
+          NavigationDestination(
+            icon: Icon(Icons.home_outlined),
+            selectedIcon: Icon(Icons.home),
             label: 'Início',
           ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.event_available),
+          NavigationDestination(
+            icon: Icon(Icons.event_available_outlined),
+            selectedIcon: Icon(Icons.event_available),
             label: 'Planos',
           ),
-          BottomNavigationBarItem(
+          NavigationDestination(
             icon: Consumer<OrderService>(
               builder: (context, orderService, child) {
                 final activeOrders = orderService.orders.where((order) => [
@@ -510,77 +419,30 @@ class _HomeScreenState extends State<HomeScreen> {
                   OrderStatus.delivery,
                 ].contains(order.status)).length;
 
-                return Stack(
-                  children: [
-                    Icon(Icons.receipt_long),
-                    if (activeOrders > 0)
-                      Positioned(
-                        right: 0,
-                        top: 0,
-                        child: Container(
-                          padding: EdgeInsets.all(1),
-                          decoration: BoxDecoration(
-                            color: Colors.red,
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                          constraints: BoxConstraints(
-                            minWidth: 12,
-                            minHeight: 12,
-                          ),
-                          child: Text(
-                            '$activeOrders',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 8,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      ),
-                  ],
+                return Badge(
+                  isLabelVisible: activeOrders > 0,
+                  label: Text('$activeOrders'),
+                  child: Icon(Icons.receipt_long_outlined),
                 );
               },
             ),
+            selectedIcon: Icon(Icons.receipt_long),
             label: 'Pedidos',
           ),
-          BottomNavigationBarItem(
+          NavigationDestination(
             icon: Consumer<CartService>(
               builder: (context, cartService, child) {
-                return Stack(
-                  children: [
-                    Icon(Icons.shopping_cart),
-                    if (cartService.itemCount > 0)
-                      Positioned(
-                        right: 0,
-                        top: 0,
-                        child: Container(
-                          padding: EdgeInsets.all(1),
-                          decoration: BoxDecoration(
-                            color: Colors.red,
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                          constraints: BoxConstraints(
-                            minWidth: 12,
-                            minHeight: 12,
-                          ),
-                          child: Text(
-                            '${cartService.itemCount}',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 8,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      ),
-                  ],
+                return Badge(
+                  isLabelVisible: cartService.itemCount > 0,
+                  label: Text('${cartService.itemCount}'),
+                  child: Icon(Icons.shopping_cart_outlined),
                 );
               },
             ),
+            selectedIcon: Icon(Icons.shopping_cart),
             label: 'Carrinho',
           ),
         ],
-        //selectedItemColor: Colors.white,
       ),
     );
   }

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -58,32 +58,47 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     final authService = Provider.of<AuthService>(context);
     final isLoading = authService.isLoading;
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
       body: SafeArea(
         child: Center(
           child: SingleChildScrollView(
-            padding: EdgeInsets.all(20),
+            padding: EdgeInsets.all(24),
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Icon(
-                  Icons.bakery_dining,
-                  size: 80,
-                  color: Colors.brown[700],
-                ),
-                SizedBox(height: 20),
-                Text(
-                  'Bem-vindo à Padaria App',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.brown[800],
+                // Marca
+                Container(
+                  height: 88,
+                  width: 88,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: colorScheme.primaryContainer,
+                    shape: BoxShape.circle,
                   ),
+                  child: Icon(
+                    Icons.bakery_dining,
+                    size: 46,
+                    color: colorScheme.onPrimaryContainer,
+                  ),
+                ),
+                SizedBox(height: 24),
+                Text(
+                  'Bem-vindo de volta',
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
                   textAlign: TextAlign.center,
                 ),
-                SizedBox(height: 40),
+                SizedBox(height: 6),
+                Text(
+                  'Entre para continuar na Padaria',
+                  style: TextStyle(fontSize: 15, color: colorScheme.onSurfaceVariant),
+                  textAlign: TextAlign.center,
+                ),
+                SizedBox(height: 36),
                 Form(
                   key: _formKey,
                   child: Column(
@@ -158,25 +173,21 @@ class _LoginScreenState extends State<LoginScreen> {
                           ),
                         ],
                       ),
-                      SizedBox(height: 20),
-                      ElevatedButton(
+                      SizedBox(height: 24),
+                      FilledButton(
                         onPressed: isLoading ? null : _submitForm,
                         child: isLoading
-                            ? CircularProgressIndicator(
-                                valueColor:
-                                    AlwaysStoppedAnimation<Color>(Colors.white),
+                            ? SizedBox(
+                                height: 22,
+                                width: 22,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2.5,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                    Theme.of(context).colorScheme.onPrimary,
+                                  ),
+                                ),
                               )
-                            : Text(
-                                'Entrar',
-                                style: TextStyle(fontSize: 16),
-                              ),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.brown[700],
-                          padding: EdgeInsets.symmetric(vertical: 15),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                        ),
+                            : Text('Entrar'),
                       ),
                     ],
                   ),
@@ -193,12 +204,12 @@ class _LoginScreenState extends State<LoginScreen> {
                   child: RichText(
                     text: TextSpan(
                       text: 'Não tem uma conta? ',
-                      style: TextStyle(color: Colors.black54),
+                      style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
                       children: [
                         TextSpan(
                           text: 'Cadastre-se',
                           style: TextStyle(
-                            color: Colors.brown[700],
+                            color: Theme.of(context).colorScheme.primary,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
@@ -214,7 +225,7 @@ class _LoginScreenState extends State<LoginScreen> {
                       padding: EdgeInsets.symmetric(horizontal: 10),
                       child: Text(
                         'Ou entre com',
-                        style: TextStyle(color: Colors.black54),
+                        style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
                       ),
                     ),
                     Expanded(child: Divider()),

--- a/lib/screens/order_confirmation_screen.dart
+++ b/lib/screens/order_confirmation_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/order.dart';
+import '../theme/app_theme.dart';
 import 'orders_screen.dart';
 
 class OrderConfirmationScreen extends StatelessWidget {
@@ -24,46 +25,41 @@ class OrderConfirmationScreen extends StatelessWidget {
                   children: [
                     // Ícone de sucesso
                     Container(
-                      width: 120,
-                      height: 120,
+                      width: 110,
+                      height: 110,
                       decoration: BoxDecoration(
-                        color: Colors.green,
+                        color: AppColors.successContainer,
                         shape: BoxShape.circle,
                       ),
                       child: Icon(
-                        Icons.check,
-                        color: Colors.white,
-                        size: 80,
+                        Icons.check_rounded,
+                        color: AppColors.success,
+                        size: 64,
                       ),
                     ),
                     SizedBox(height: 32),
                     // Título
                     Text(
                       'Pedido Confirmado!',
-                      style: TextStyle(
-                        fontSize: 28,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.brown[800],
-                      ),
+                      style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: Theme.of(context).colorScheme.onSurface,
+                          ),
                       textAlign: TextAlign.center,
                     ),
-                    SizedBox(height: 16),
+                    SizedBox(height: 12),
                     // Subtítulo
                     Text(
                       'Seu pedido foi recebido com sucesso',
                       style: TextStyle(
                         fontSize: 16,
-                        color: Colors.grey[600],
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
                       ),
                       textAlign: TextAlign.center,
                     ),
                     SizedBox(height: 32),
                     // Card com informações do pedido
                     Card(
-                      elevation: 4,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
                       child: Padding(
                         padding: EdgeInsets.all(20),
                         child: Column(
@@ -177,7 +173,7 @@ class OrderConfirmationScreen extends StatelessWidget {
             Container(
               padding: EdgeInsets.all(24),
               decoration: BoxDecoration(
-                color: Colors.white,
+                color: Theme.of(context).colorScheme.surface,
                 boxShadow: [
                   BoxShadow(
                     color: Colors.black.withOpacity(0.05),
@@ -189,56 +185,29 @@ class OrderConfirmationScreen extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  SizedBox(
-                    width: double.infinity,
-                    height: 50,
-                    child: ElevatedButton.icon(
-                      onPressed: () {
-                        Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                            builder: (context) => OrdersScreen(),
-                          ),
-                        );
-                      },
-                      icon: Icon(Icons.receipt_long, color: Colors.amber,),
-                      label: Text(
-                        'Ver Meus Pedidos',
-                        style: TextStyle(fontSize: 16, color: Colors.amber),
-                      ),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.brown[700],
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(10),
+                  FilledButton.icon(
+                    onPressed: () {
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => OrdersScreen(),
                         ),
-                      ),
-                    ),
+                      );
+                    },
+                    icon: Icon(Icons.receipt_long),
+                    label: Text('Ver Meus Pedidos'),
                   ),
                   SizedBox(height: 12),
-                  SizedBox(
-                    width: double.infinity,
-                    height: 50,
-                    child: OutlinedButton.icon(
-                      onPressed: () {
-                        Navigator.pushNamedAndRemoveUntil(
-                          context,
-                          '/',
-                          (route) => false,
-                        );
-                      },
-                      icon: Icon(Icons.home),
-                      label: Text(
-                        'Voltar ao Início',
-                        style: TextStyle(fontSize: 16),
-                      ),
-                      style: OutlinedButton.styleFrom(
-                        foregroundColor: Colors.brown[700],
-                        side: BorderSide(color: Colors.brown[700]!),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(10),
-                        ),
-                      ),
-                    ),
+                  OutlinedButton.icon(
+                    onPressed: () {
+                      Navigator.pushNamedAndRemoveUntil(
+                        context,
+                        '/',
+                        (route) => false,
+                      );
+                    },
+                    icon: Icon(Icons.home_outlined),
+                    label: Text('Voltar ao Início'),
                   ),
                 ],
               ),
@@ -250,6 +219,7 @@ class OrderConfirmationScreen extends StatelessWidget {
   }
 
   Widget _buildInfoRow(String label, String value) {
+    return Builder(builder: (context) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -258,7 +228,7 @@ class OrderConfirmationScreen extends StatelessWidget {
           label,
           style: TextStyle(
             fontWeight: FontWeight.w500,
-            color: Colors.grey[700],
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
           ),
         ),
         SizedBox(width: 16),
@@ -273,5 +243,6 @@ class OrderConfirmationScreen extends StatelessWidget {
         ),
       ],
     );
+    });
   }
 }

--- a/lib/screens/order_detail_screen.dart
+++ b/lib/screens/order_detail_screen.dart
@@ -4,6 +4,7 @@ import '../models/order.dart';
 import '../services/order_service.dart';
 import '../services/auth_service.dart';
 import '../services/api_client.dart';
+import '../theme/app_theme.dart';
 
 class OrderDetailScreen extends StatelessWidget {
   final Order order;
@@ -15,7 +16,6 @@ class OrderDetailScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text('Pedido #${order.id.substring(0, 8)}'),
-        backgroundColor: Colors.brown,
         actions: [
           IconButton(
             icon: Icon(Icons.refresh),
@@ -45,7 +45,7 @@ class OrderDetailScreen extends StatelessWidget {
             SizedBox(height: 16),
 
             // Itens do pedido
-            _buildOrderItems(),
+            _buildOrderItems(context),
 
             SizedBox(height: 16),
 
@@ -74,8 +74,6 @@ class OrderDetailScreen extends StatelessWidget {
 
   Widget _buildStatusCard() {
     return Card(
-      elevation: 3,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Container(
         width: double.infinity,
         padding: EdgeInsets.all(20),
@@ -123,8 +121,6 @@ class OrderDetailScreen extends StatelessWidget {
 
   Widget _buildOrderInfo() {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -147,10 +143,9 @@ class OrderDetailScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildOrderItems() {
+  Widget _buildOrderItems(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -180,7 +175,7 @@ class OrderDetailScreen extends StatelessWidget {
                     height: 60,
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(8),
-                      color: Colors.grey[200],
+                      color: colorScheme.surfaceContainerHighest,
                     ),
                     child: item.product.imageUrl.startsWith('assets/')
                         ? ClipRRect(
@@ -192,7 +187,7 @@ class OrderDetailScreen extends StatelessWidget {
                             Icon(Icons.image_not_supported),
                       ),
                     )
-                        : Icon(Icons.fastfood, color: Colors.brown),
+                        : Icon(Icons.fastfood, color: colorScheme.primary),
                   ),
                   SizedBox(width: 12),
                   // Informações do item
@@ -242,7 +237,7 @@ class OrderDetailScreen extends StatelessWidget {
                         'R\$ ${item.totalPrice.toStringAsFixed(2)}',
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
-                          color: Colors.brown[700],
+                          color: colorScheme.primary,
                           fontSize: 16,
                         ),
                       ),
@@ -259,8 +254,6 @@ class OrderDetailScreen extends StatelessWidget {
 
   Widget _buildDeliveryInfo() {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -284,8 +277,6 @@ class OrderDetailScreen extends StatelessWidget {
 
   Widget _buildPaymentInfo() {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -309,8 +300,6 @@ class OrderDetailScreen extends StatelessWidget {
 
   Widget _buildRecurringInfo() {
     return Card(
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Padding(
         padding: EdgeInsets.all(16),
         child: Column(
@@ -373,23 +362,18 @@ class OrderDetailScreen extends StatelessWidget {
   Widget _buildActionButtons(BuildContext context) {
     List<Widget> buttons = [];
 
+    final colorScheme = Theme.of(context).colorScheme;
+
     // Botão de cancelar pedido (apenas para pedidos ativos)
     if ([OrderStatus.pending, OrderStatus.confirmed].contains(order.status)) {
       buttons.add(
-        SizedBox(
-          width: double.infinity,
-          height: 50,
-          child: OutlinedButton.icon(
-            onPressed: () => _showCancelDialog(context),
-            icon: Icon(Icons.cancel),
-            label: Text('Cancelar Pedido'),
-            style: OutlinedButton.styleFrom(
-              foregroundColor: Colors.red,
-              side: BorderSide(color: Colors.red),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-            ),
+        OutlinedButton.icon(
+          onPressed: () => _showCancelDialog(context),
+          icon: Icon(Icons.cancel_outlined),
+          label: Text('Cancelar Pedido'),
+          style: OutlinedButton.styleFrom(
+            foregroundColor: colorScheme.error,
+            side: BorderSide(color: colorScheme.error),
           ),
         ),
       );
@@ -399,20 +383,10 @@ class OrderDetailScreen extends StatelessWidget {
     // Botão de reordenar (para pedidos concluídos)
     if (order.status == OrderStatus.completed) {
       buttons.add(
-        SizedBox(
-          width: double.infinity,
-          height: 50,
-          child: ElevatedButton.icon(
-            onPressed: () => _reorderItems(context),
-            icon: Icon(Icons.refresh),
-            label: Text('Fazer Pedido Novamente'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.brown[700],
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-            ),
-          ),
+        FilledButton.icon(
+          onPressed: () => _reorderItems(context),
+          icon: Icon(Icons.refresh),
+          label: Text('Fazer Pedido Novamente'),
         ),
       );
       buttons.add(SizedBox(height: 12));
@@ -420,21 +394,10 @@ class OrderDetailScreen extends StatelessWidget {
 
     // Botão de suporte
     buttons.add(
-      SizedBox(
-        width: double.infinity,
-        height: 50,
-        child: OutlinedButton.icon(
-          onPressed: () => _contactSupport(context),
-          icon: Icon(Icons.help_outline),
-          label: Text('Entrar em Contato'),
-          style: OutlinedButton.styleFrom(
-            foregroundColor: Colors.brown[700],
-            side: BorderSide(color: Colors.brown[300]!),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(10),
-            ),
-          ),
-        ),
+      OutlinedButton.icon(
+        onPressed: () => _contactSupport(context),
+        icon: Icon(Icons.help_outline),
+        label: Text('Entrar em Contato'),
       ),
     );
 
@@ -551,14 +514,14 @@ class OrderDetailScreen extends StatelessWidget {
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: Text('Pedido cancelado com sucesso'),
-                      backgroundColor: Colors.green,
+                      backgroundColor: AppColors.success,
                     ),
                   );
                 } catch (e) {
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: Text(e is ApiException ? e.message : 'Não foi possível cancelar o pedido.'),
-                      backgroundColor: Colors.red,
+                      backgroundColor: Theme.of(context).colorScheme.error,
                     ),
                   );
                 }
@@ -577,7 +540,7 @@ class OrderDetailScreen extends StatelessWidget {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text('Itens adicionados ao carrinho!'),
-        backgroundColor: Colors.green,
+        backgroundColor: AppColors.success,
         action: SnackBarAction(
           label: 'Ver Carrinho',
           onPressed: () {

--- a/lib/screens/orders_screen.dart
+++ b/lib/screens/orders_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../models/order.dart';
 import '../services/order_service.dart';
 import '../services/auth_service.dart';
+import '../theme/app_theme.dart';
 import 'order_detail_screen.dart';
 
 class OrdersScreen extends StatefulWidget {
@@ -36,12 +37,8 @@ class _OrdersScreenState extends State<OrdersScreen> with TickerProviderStateMix
     return Scaffold(
       appBar: AppBar(
         title: Text('Meus Pedidos'),
-        backgroundColor: Colors.brown,
         bottom: TabBar(
           controller: _tabController,
-          indicatorColor: Colors.brown[200],
-          labelColor: Colors.brown[50],
-          unselectedLabelColor: Colors.white70,
           tabs: [
             Tab(
               icon: Icon(Icons.pending_actions),
@@ -77,35 +74,40 @@ class _OrdersScreenState extends State<OrdersScreen> with TickerProviderStateMix
   }
 
   Widget _buildNotAuthenticated() {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.login,
-            size: 80,
-            color: Colors.grey[400],
-          ),
-          SizedBox(height: 24),
-          Text(
-            'Faça login para ver seus pedidos',
-            style: TextStyle(
-              fontSize: 18,
-              color: Colors.grey[600],
+    return Builder(
+      builder: (context) {
+        final colorScheme = Theme.of(context).colorScheme;
+        return Center(
+          child: Padding(
+            padding: EdgeInsets.all(32),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.login,
+                  size: 72,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                SizedBox(height: 20),
+                Text(
+                  'Faça login para ver seus pedidos',
+                  style: TextStyle(
+                    fontSize: 17,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                SizedBox(height: 24),
+                FilledButton(
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/login');
+                  },
+                  child: Text('Fazer Login'),
+                ),
+              ],
             ),
           ),
-          SizedBox(height: 24),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.pushNamed(context, '/login');
-            },
-            child: Text('Fazer Login'),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.brown[700],
-            ),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 
@@ -200,35 +202,50 @@ class _OrdersScreenState extends State<OrdersScreen> with TickerProviderStateMix
     required String title,
     required String subtitle,
   }) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            icon,
-            size: 80,
-            color: Colors.grey[400],
-          ),
-          SizedBox(height: 24),
-          Text(
-            title,
-            style: TextStyle(
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
-              color: Colors.grey[600],
+    return Builder(
+      builder: (context) {
+        final colorScheme = Theme.of(context).colorScheme;
+        return Center(
+          child: Padding(
+            padding: EdgeInsets.all(32),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  padding: EdgeInsets.all(24),
+                  decoration: BoxDecoration(
+                    color: colorScheme.surfaceContainerHighest,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    icon,
+                    size: 56,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                SizedBox(height: 24),
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 19,
+                    fontWeight: FontWeight.w700,
+                    color: colorScheme.onSurface,
+                  ),
+                ),
+                SizedBox(height: 8),
+                Text(
+                  subtitle,
+                  style: TextStyle(
+                    fontSize: 15,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
             ),
           ),
-          SizedBox(height: 8),
-          Text(
-            subtitle,
-            style: TextStyle(
-              fontSize: 16,
-              color: Colors.grey[500],
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 }
@@ -246,13 +263,12 @@ class OrderCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Card(
       margin: EdgeInsets.only(bottom: 12),
-      elevation: 2,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppRadii.md),
         child: Padding(
           padding: EdgeInsets.all(16),
           child: Column(
@@ -297,11 +313,11 @@ class OrderCard extends StatelessWidget {
               // Informações do pedido
               Row(
                 children: [
-                  Icon(Icons.calendar_today, size: 16, color: Colors.grey[600]),
+                  Icon(Icons.calendar_today, size: 16, color: colorScheme.onSurfaceVariant),
                   SizedBox(width: 8),
                   Text(
                     order.formattedOrderDate,
-                    style: TextStyle(color: Colors.grey[600]),
+                    style: TextStyle(color: colorScheme.onSurfaceVariant),
                   ),
                 ],
               ),
@@ -310,12 +326,12 @@ class OrderCard extends StatelessWidget {
 
               Row(
                 children: [
-                  Icon(Icons.delivery_dining, size: 16, color: Colors.grey[600]),
+                  Icon(Icons.delivery_dining, size: 16, color: colorScheme.onSurfaceVariant),
                   SizedBox(width: 8),
                   Expanded(
                     child: Text(
                       'Entrega: ${order.formattedDeliveryDate}',
-                      style: TextStyle(color: Colors.grey[600]),
+                      style: TextStyle(color: colorScheme.onSurfaceVariant),
                     ),
                   ),
                 ],
@@ -345,7 +361,7 @@ class OrderCard extends StatelessWidget {
                 'Itens: ${order.items.map((item) => '${item.quantity}x ${item.product.name}').join(', ')}',
                 style: TextStyle(
                   fontSize: 14,
-                  color: Colors.grey[700],
+                  color: colorScheme.onSurfaceVariant,
                 ),
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
@@ -362,7 +378,7 @@ class OrderCard extends StatelessWidget {
                     style: TextStyle(
                       fontSize: 18,
                       fontWeight: FontWeight.bold,
-                      color: Colors.brown[700],
+                      color: colorScheme.primary,
                     ),
                   ),
                   Row(
@@ -370,15 +386,15 @@ class OrderCard extends StatelessWidget {
                       Text(
                         'Ver detalhes',
                         style: TextStyle(
-                          color: Colors.brown[600],
-                          fontWeight: FontWeight.w500,
+                          color: colorScheme.primary,
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
                       SizedBox(width: 4),
                       Icon(
                         Icons.arrow_forward_ios,
-                        size: 16,
-                        color: Colors.brown[600],
+                        size: 14,
+                        color: colorScheme.primary,
                       ),
                     ],
                   ),

--- a/lib/screens/plan_details_screen.dart
+++ b/lib/screens/plan_details_screen.dart
@@ -12,10 +12,9 @@ class PlanDetailsScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text('Detalhes do Plano'),
-        backgroundColor: Colors.brown,
         actions: [
           IconButton(
-            icon: Icon(Icons.edit),
+            icon: Icon(Icons.edit_outlined),
             onPressed: () {
               Navigator.of(context).push(
                 MaterialPageRoute(builder: (ctx) => PlansScreen(editingPlan: plan)),
@@ -31,12 +30,12 @@ class PlanDetailsScreen extends StatelessWidget {
           children: [
             Text(
               'Plano de Assinatura',
-              style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold, color: Colors.brown),
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
             ),
             SizedBox(height: 16),
             Card(
-              elevation: 4,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
               child: Padding(
                 padding: EdgeInsets.all(16),
                 child: Column(
@@ -44,7 +43,7 @@ class PlanDetailsScreen extends StatelessWidget {
                   children: [
                     Text(
                       plan.templateName,
-                      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Colors.brown),
+                      style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold, color: Theme.of(context).colorScheme.primary),
                     ),
                     SizedBox(height: 8),
                     _buildDetailRow('Status:', plan.active ? 'Ativo' : 'Inativo'),
@@ -71,17 +70,12 @@ class PlanDetailsScreen extends StatelessWidget {
               ),
             ),
             SizedBox(height: 24),
-            Center(
-              child: ElevatedButton(
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
                 onPressed: () {
                   Navigator.of(context).pop(); // Volta para a tela anterior
                 },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.brown.shade200,
-                  foregroundColor: Colors.brown.shade900,
-                  padding: EdgeInsets.symmetric(horizontal: 40, vertical: 15),
-                  textStyle: TextStyle(fontSize: 18),
-                ),
                 child: Text('Voltar'),
               ),
             ),

--- a/lib/screens/plans_screen.dart
+++ b/lib/screens/plans_screen.dart
@@ -8,6 +8,7 @@ import '../models/cart_item.dart';
 import '../models/product.dart';
 import '../models/subscription_plan.dart';
 import '../models/subscription_template.dart';
+import '../theme/app_theme.dart';
 import 'plan_details_screen.dart';
 
 class PlansScreen extends StatefulWidget {
@@ -200,7 +201,7 @@ class _PlansScreenState extends State<PlansScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(e is ApiException ? e.message : 'Não foi possível salvar o plano.'),
-          backgroundColor: Colors.red,
+          backgroundColor: Theme.of(context).colorScheme.error,
         ),
       );
     } finally {
@@ -209,8 +210,9 @@ class _PlansScreenState extends State<PlansScreen> {
   }
 
   Widget _buildTemplatePicker(List<SubscriptionTemplate> templates) {
+    final colorScheme = Theme.of(context).colorScheme;
     if (templates.isEmpty) {
-      return Text('Nenhum plano disponível no momento.', style: TextStyle(color: Colors.grey[600]));
+      return Text('Nenhum plano disponível no momento.', style: TextStyle(color: colorScheme.onSurfaceVariant));
     }
     return SizedBox(
       height: 130,
@@ -222,13 +224,16 @@ class _PlansScreenState extends State<PlansScreen> {
           final selected = _selectedTemplate?.id == template.id;
           return Card(
             margin: EdgeInsets.only(right: 12),
-            color: selected ? Colors.brown[100] : null,
+            color: selected ? colorScheme.primaryContainer : null,
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(10),
-              side: BorderSide(color: selected ? Colors.brown : Colors.transparent, width: 2),
+              borderRadius: BorderRadius.circular(AppRadii.md),
+              side: BorderSide(
+                color: selected ? colorScheme.primary : colorScheme.outlineVariant.withOpacity(0.5),
+                width: selected ? 2 : 1,
+              ),
             ),
             child: InkWell(
-              borderRadius: BorderRadius.circular(10),
+              borderRadius: BorderRadius.circular(AppRadii.md),
               onTap: () => _selectTemplate(template),
               child: Container(
                 width: 160,
@@ -240,14 +245,14 @@ class _PlansScreenState extends State<PlansScreen> {
                     SizedBox(height: 4),
                     Text(
                       template.description,
-                      style: TextStyle(fontSize: 12, color: Colors.grey[700]),
+                      style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                     ),
                     Spacer(),
                     Text(
                       '${template.products.length} produtos disponíveis',
-                      style: TextStyle(fontSize: 11, color: Colors.brown[700]),
+                      style: TextStyle(fontSize: 11, color: colorScheme.primary, fontWeight: FontWeight.w600),
                     ),
                   ],
                 ),
@@ -274,7 +279,7 @@ class _PlansScreenState extends State<PlansScreen> {
                 borderRadius: BorderRadius.circular(8),
                 child: product.imageUrl.startsWith('assets/')
                     ? Image.asset(product.imageUrl, fit: BoxFit.cover)
-                    : Icon(Icons.fastfood, color: Colors.brown),
+                    : Icon(Icons.fastfood, color: Theme.of(context).colorScheme.primary),
               ),
             ),
             SizedBox(width: 12),
@@ -289,7 +294,7 @@ class _PlansScreenState extends State<PlansScreen> {
               ),
             ),
             IconButton(
-              icon: Icon(selected ? Icons.check_circle : Icons.add_circle_outline, color: Colors.brown),
+              icon: Icon(selected ? Icons.check_circle : Icons.add_circle_outline, color: Theme.of(context).colorScheme.primary),
               onPressed: () {
                 setState(() {
                   _selectedQuantities[product.productId] = selected ? 0 : 1;
@@ -332,7 +337,6 @@ class _PlansScreenState extends State<PlansScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.editingPlan != null ? 'Editar Plano' : 'Plano de Assinatura'),
-        backgroundColor: Colors.brown,
       ),
       body: Consumer<SubscriptionService>(
         builder: (context, subscriptionService, child) {
@@ -370,7 +374,6 @@ class _PlansScreenState extends State<PlansScreen> {
                     return ChoiceChip(
                       label: Text(d),
                       selected: selected,
-                      selectedColor: Colors.brown[200],
                       onSelected: (val) {
                         setState(() {
                           if (val) {
@@ -390,19 +393,26 @@ class _PlansScreenState extends State<PlansScreen> {
                   children: [
                     Expanded(
                       child: Container(
-                        padding: EdgeInsets.symmetric(vertical: 12, horizontal: 12),
+                        padding: EdgeInsets.symmetric(vertical: 14, horizontal: 12),
                         decoration: BoxDecoration(
-                          border: Border.all(color: Colors.black12),
-                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: Theme.of(context).colorScheme.outlineVariant),
+                          borderRadius: BorderRadius.circular(AppRadii.sm),
                         ),
-                        child: Text(_time.isEmpty ? 'Selecione o horário' : _time),
+                        child: Text(
+                          _time.isEmpty ? 'Selecione o horário' : _time,
+                          style: TextStyle(
+                            color: _time.isEmpty
+                                ? Theme.of(context).colorScheme.onSurfaceVariant
+                                : Theme.of(context).colorScheme.onSurface,
+                          ),
+                        ),
                       ),
                     ),
                     SizedBox(width: 8),
-                    ElevatedButton(
+                    FilledButton.tonalIcon(
                       onPressed: _pickTime,
-                      style: ElevatedButton.styleFrom(backgroundColor: Colors.white30),
-                      child: Text('Escolher'),
+                      icon: Icon(Icons.access_time),
+                      label: Text('Escolher'),
                     ),
                   ],
                 ),
@@ -411,14 +421,10 @@ class _PlansScreenState extends State<PlansScreen> {
                 SizedBox(height: 8),
                 Align(
                   alignment: Alignment.center,
-                  child: ElevatedButton.icon(
+                  child: OutlinedButton.icon(
                     onPressed: _useUserAddress,
-                    icon: Icon(Icons.person_pin_circle),
+                    icon: Icon(Icons.person_pin_circle_outlined),
                     label: Text('Usar endereço do perfil'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.white30,
-                      padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                    ),
                   ),
                 ),
                 SizedBox(height: 8),
@@ -435,10 +441,8 @@ class _PlansScreenState extends State<PlansScreen> {
                     Switch(
                       value: _active,
                       onChanged: (v) => setState(() => _active = v),
-                      activeColor: Colors.brown,
-                      inactiveThumbColor: Colors.brown[200],
-                      inactiveTrackColor: Colors.brown[100],
                     ),
+                    SizedBox(width: 4),
                     Text('Plano ativo'),
                   ],
                 ),
@@ -465,15 +469,19 @@ class _PlansScreenState extends State<PlansScreen> {
                   ),
                 ),
                 SizedBox(height: 16),
-                ElevatedButton(
+                FilledButton(
                   onPressed: _isSaving ? null : () => _savePlan(context),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.brown[200],
-                    padding: EdgeInsets.symmetric(horizontal: 30, vertical: 15),
-                    textStyle: TextStyle(fontSize: 18),
-                  ),
                   child: _isSaving
-                      ? SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                      ? SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              Theme.of(context).colorScheme.onPrimary,
+                            ),
+                          ),
+                        )
                       : Text('Salvar Plano'),
                 ),
               ],

--- a/lib/screens/product_detail_screen.dart
+++ b/lib/screens/product_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../models/product.dart';
 import '../services/cart_service.dart';
 import '../widgets/product_image.dart';
+import '../theme/app_theme.dart';
 import 'cart_screen.dart';
 
 class ProductDetailScreen extends StatefulWidget {
@@ -20,10 +21,10 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.product.name),
-        backgroundColor: Colors.brown,
       ),
       body: SingleChildScrollView(
         child: Column(
@@ -33,9 +34,7 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
             Container(
               height: 300,
               width: double.infinity,
-              decoration: BoxDecoration(
-                color: Colors.grey[200],
-              ),
+              color: colorScheme.surfaceContainerHighest,
               child: ProductImage(product: widget.product, iconSize: 100),
             ),
 
@@ -62,7 +61,7 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
                         style: TextStyle(
                           fontSize: 24,
                           fontWeight: FontWeight.bold,
-                          color: Colors.brown[700],
+                          color: colorScheme.primary,
                         ),
                       ),
                     ],
@@ -74,14 +73,14 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
                   Container(
                     padding: EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                     decoration: BoxDecoration(
-                      color: Colors.brown[100],
+                      color: colorScheme.secondaryContainer,
                       borderRadius: BorderRadius.circular(20),
                     ),
                     child: Text(
                       widget.product.category,
                       style: TextStyle(
-                        color: Colors.brown[700],
-                        fontWeight: FontWeight.w500,
+                        color: colorScheme.onSecondaryContainer,
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),
@@ -101,7 +100,7 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
                     widget.product.description,
                     style: TextStyle(
                       fontSize: 16,
-                      color: Colors.grey[700],
+                      color: colorScheme.onSurfaceVariant,
                       height: 1.5,
                     ),
                   ),
@@ -119,23 +118,21 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
                   SizedBox(height: 8),
                   Row(
                     children: [
-                      IconButton(
+                      IconButton.filledTonal(
                         onPressed: quantity > 1 ? () {
                           setState(() {
                             quantity--;
                           });
                         } : null,
                         icon: Icon(Icons.remove),
-                        style: IconButton.styleFrom(
-                          backgroundColor: Colors.grey[200],
-                        ),
                       ),
                       Container(
                         width: 60,
-                        height: 40,
+                        height: 44,
+                        margin: EdgeInsets.symmetric(horizontal: 8),
                         decoration: BoxDecoration(
-                          border: Border.all(color: Colors.grey[300]!),
-                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: colorScheme.outlineVariant),
+                          borderRadius: BorderRadius.circular(10),
                         ),
                         child: Center(
                           child: Text(
@@ -147,16 +144,13 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
                           ),
                         ),
                       ),
-                      IconButton(
+                      IconButton.filled(
                         onPressed: () {
                           setState(() {
                             quantity++;
                           });
                         },
                         icon: Icon(Icons.add),
-                        style: IconButton.styleFrom(
-                          backgroundColor: Colors.brown[200],
-                        ),
                       ),
                       Spacer(),
                       Text(
@@ -164,7 +158,7 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
                         style: TextStyle(
                           fontSize: 18,
                           fontWeight: FontWeight.bold,
-                          color: Colors.brown[700],
+                          color: colorScheme.primary,
                         ),
                       ),
                     ],
@@ -195,113 +189,61 @@ class _ProductDetailScreenState extends State<ProductDetailScreen> {
                   SizedBox(height: 32),
 
                   // Botão de adicionar ao carrinho
-                  SizedBox(
-                    width: double.infinity,
-                    height: 50,
-                    child: Consumer<CartService>(
-                      builder: (context, cartService, child) {
-                        return ElevatedButton.icon(
-                          onPressed: widget.product.isAvailable ? () {
-                            cartService.addItem(
-                              widget.product,
-                              quantity: quantity,
-                              notes: notesController.text.trim().isEmpty
-                                  ? null
-                                  : notesController.text.trim(),
-                            );
+                  Consumer<CartService>(
+                    builder: (context, cartService, child) {
+                      return FilledButton.icon(
+                        onPressed: widget.product.isAvailable ? () {
+                          cartService.addItem(
+                            widget.product,
+                            quantity: quantity,
+                            notes: notesController.text.trim().isEmpty
+                                ? null
+                                : notesController.text.trim(),
+                          );
 
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(
-                                content: Text(
-                                  '${widget.product.name} adicionado ao carrinho (${quantity}x)',
-                                ),
-                                duration: Duration(seconds: 2),
-                                backgroundColor: Colors.green,
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                '${widget.product.name} adicionado ao carrinho (${quantity}x)',
                               ),
-                            );
-
-                            Navigator.pop(context);
-                          } : null,
-                          icon: Icon(Icons.add_shopping_cart),
-                          label: Text(
-                            widget.product.isAvailable
-                                ? 'Adicionar ao Carrinho'
-                                : 'Produto Indisponível',
-                            style: TextStyle(fontSize: 16),
-                          ),
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: widget.product.isAvailable
-                                ? Colors.brown[700]
-                                : Colors.grey,
-                            foregroundColor: Colors.white, // texto com contraste melhor
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10),
+                              duration: Duration(seconds: 2),
+                              backgroundColor: AppColors.success,
                             ),
-                          ),
-                        );
-                      },
-                    ),
+                          );
+
+                          Navigator.pop(context);
+                        } : null,
+                        icon: Icon(Icons.add_shopping_cart),
+                        label: Text(
+                          widget.product.isAvailable
+                              ? 'Adicionar ao Carrinho'
+                              : 'Produto Indisponível',
+                        ),
+                      );
+                    },
                   ),
 
-                  SizedBox(height: 16),
+                  SizedBox(height: 12),
 
                   // Botão de ver carrinho
-                  SizedBox(
-                    width: double.infinity,
-                    height: 50,
-                    child: Consumer<CartService>(
-                      builder: (context, cartService, child) {
-                        return OutlinedButton.icon(
-                          onPressed: () {
-                            // Navegar para o carrinho (usa rota explícita com MaterialPageRoute)
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(builder: (context) => CartScreen()),
-                            );
-                          },
-                          icon: Stack(
-                            clipBehavior: Clip.none,
-                            children: [
-                              Icon(Icons.shopping_cart),
-                              if (cartService.itemCount > 0)
-                                Positioned(
-                                  right: -6,
-                                  top: -6,
-                                  child: Container(
-                                    padding: EdgeInsets.all(4),
-                                    decoration: BoxDecoration(
-                                      color: Colors.red,
-                                      shape: BoxShape.circle,
-                                    ),
-                                    constraints: BoxConstraints(minWidth: 18, minHeight: 18),
-                                    child: Center(
-                                      child: Text(
-                                        '${cartService.itemCount}',
-                                        style: TextStyle(
-                                          color: Colors.white,
-                                          fontSize: 10,
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                            ],
-                          ),
-                          label: Text(
-                            'Ver Carrinho (${cartService.itemCount})',
-                            style: TextStyle(fontSize: 16, color: Colors.brown.shade900),
-                          ),
-                          style: OutlinedButton.styleFrom(
-                            foregroundColor: Colors.brown.shade900,
-                            side: BorderSide(color: Colors.brown[700]!),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
+                  Consumer<CartService>(
+                    builder: (context, cartService, child) {
+                      return OutlinedButton.icon(
+                        onPressed: () {
+                          // Navegar para o carrinho (usa rota explícita com MaterialPageRoute)
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => CartScreen()),
+                          );
+                        },
+                        icon: Badge(
+                          isLabelVisible: cartService.itemCount > 0,
+                          label: Text('${cartService.itemCount}'),
+                          child: Icon(Icons.shopping_cart_outlined),
+                        ),
+                        label: Text('Ver Carrinho (${cartService.itemCount})'),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/lib/screens/products_screen.dart
+++ b/lib/screens/products_screen.dart
@@ -4,6 +4,7 @@ import '../models/product.dart';
 import '../services/product_service.dart';
 import '../services/cart_service.dart';
 import '../widgets/product_image.dart';
+import '../theme/app_theme.dart';
 import 'product_detail_screen.dart';
 
 class ProductsScreen extends StatefulWidget {
@@ -32,7 +33,6 @@ class _ProductsScreenState extends State<ProductsScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Produtos'),
-        backgroundColor: Colors.brown,
         actions: [
           IconButton(
             icon: Icon(Icons.search),
@@ -86,7 +86,6 @@ class _ProductsScreenState extends State<ProductsScreen> {
                               selectedCategory = null;
                             });
                           },
-                          selectedColor: Colors.brown[300],
                         ),
                       );
                     }
@@ -102,7 +101,6 @@ class _ProductsScreenState extends State<ProductsScreen> {
                             selectedCategory = selected ? category : null;
                           });
                         },
-                        selectedColor: Colors.brown[300],
                       ),
                     );
                   },
@@ -141,6 +139,7 @@ class ProductCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return GestureDetector(
       onTap: () {
         Navigator.push(
@@ -151,8 +150,6 @@ class ProductCard extends StatelessWidget {
         );
       },
       child: Card(
-        elevation: 4,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -160,13 +157,10 @@ class ProductCard extends StatelessWidget {
               flex: 5,
               child: Container(
                 width: double.infinity,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
-                  color: Colors.grey[200],
-                ),
+                color: colorScheme.surfaceContainerHighest,
                 child: ProductImage(
                   product: product,
-                  borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadii.md)),
                 ),
               ),
             ),
@@ -192,7 +186,7 @@ class ProductCard extends StatelessWidget {
                       product.description,
                       style: TextStyle(
                         fontSize: 12,
-                        color: Colors.grey[600],
+                        color: colorScheme.onSurfaceVariant,
                       ),
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
@@ -207,7 +201,7 @@ class ProductCard extends StatelessWidget {
                             'R\$ ${product.price.toStringAsFixed(2)}',
                             style: TextStyle(
                               fontWeight: FontWeight.bold,
-                              color: Colors.brown[700],
+                              color: colorScheme.primary,
                               fontSize: 15,
                             ),
                             overflow: TextOverflow.ellipsis,
@@ -217,7 +211,10 @@ class ProductCard extends StatelessWidget {
                         Consumer<CartService>(
                           builder: (context, cartService, child) {
                             return Material(
-                              color: Colors.transparent,
+                              color: product.isAvailable
+                                  ? colorScheme.primaryContainer
+                                  : colorScheme.surfaceContainerHighest,
+                              borderRadius: BorderRadius.circular(10),
                               child: InkWell(
                                 onTap: product.isAvailable ? () {
                                   cartService.addItem(product);
@@ -225,16 +222,18 @@ class ProductCard extends StatelessWidget {
                                     SnackBar(
                                       content: Text('${product.name} adicionado ao carrinho'),
                                       duration: Duration(seconds: 2),
-                                      backgroundColor: Colors.green,
+                                      backgroundColor: AppColors.success,
                                     ),
                                   );
                                 } : null,
-                                borderRadius: BorderRadius.circular(20),
+                                borderRadius: BorderRadius.circular(10),
                                 child: Padding(
-                                  padding: EdgeInsets.all(4),
+                                  padding: EdgeInsets.all(7),
                                   child: Icon(
                                     Icons.add_shopping_cart,
-                                    color: product.isAvailable ? Colors.brown : Colors.grey,
+                                    color: product.isAvailable
+                                        ? colorScheme.onPrimaryContainer
+                                        : colorScheme.onSurfaceVariant,
                                     size: 20,
                                   ),
                                 ),
@@ -319,9 +318,9 @@ class ProductSearchDelegate extends SearchDelegate<String> {
                 height: 50,
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(8),
-                  color: Colors.grey[200],
+                  color: Theme.of(context).colorScheme.surfaceContainerHighest,
                 ),
-                child: Icon(Icons.fastfood, color: Colors.brown),
+                child: Icon(Icons.fastfood, color: Theme.of(context).colorScheme.primary),
               ),
               title: Text(product.name),
               subtitle: Text('R\$ ${product.price.toStringAsFixed(2)}'),

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -73,7 +73,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
           return Scaffold(
             appBar: AppBar(
               title: Text('Meu Perfil'),
-              backgroundColor: Colors.brown,
             ),
             body: Center(
               child: Text('Faça login para visualizar seu perfil.'),
@@ -84,7 +83,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
         return Scaffold(
           appBar: AppBar(
             title: Text('Meu Perfil'),
-            backgroundColor: Colors.brown,
             actions: [
               IconButton(
                 icon: Icon(Icons.logout),
@@ -99,21 +97,19 @@ class _ProfileScreenState extends State<ProfileScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Card(
-                  elevation: 3,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                   child: Padding(
                     padding: EdgeInsets.all(16),
                     child: Row(
                       children: [
                         CircleAvatar(
                           radius: 32,
-                          backgroundColor: Colors.brown[200],
+                          backgroundColor: Theme.of(context).colorScheme.primaryContainer,
                           child: Text(
                             user.name.isNotEmpty ? user.name[0].toUpperCase() : '?',
                             style: TextStyle(
                               fontSize: 24,
                               fontWeight: FontWeight.bold,
-                              color: Colors.brown[900],
+                              color: Theme.of(context).colorScheme.onPrimaryContainer,
                             ),
                           ),
                         ),
@@ -127,11 +123,14 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                               ),
                               SizedBox(height: 4),
-                              Text(user.email),
+                              Text(
+                                user.email,
+                                style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                              ),
                               SizedBox(height: 8),
                               Row(
                                 children: [
-                                  Icon(Icons.loyalty, color: Colors.orangeAccent),
+                                  Icon(Icons.loyalty, color: Colors.amber[700], size: 20),
                                   SizedBox(width: 8),
                                   Text('${user.loyaltyPoints} pontos de fidelidade'),
                                 ],
@@ -146,7 +145,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 SizedBox(height: 24),
                 Text(
                   'Informações do Perfil',
-                  style: Theme.of(context).textTheme.displayMedium,
+                  style: Theme.of(context).textTheme.titleLarge,
                 ),
                 SizedBox(height: 12),
                 Form(
@@ -205,17 +204,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         maxLines: 2,
                       ),
                       SizedBox(height: 24),
-                      SizedBox(
-                        width: double.infinity,
-                        child: ElevatedButton.icon(
-                          icon: Icon(Icons.save),
-                          label: Text('Salvar alterações'),
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.brown[700],
-                            padding: EdgeInsets.symmetric(vertical: 14),
-                          ),
-                          onPressed: authService.isLoading ? null : _saveProfile,
-                        ),
+                      FilledButton.icon(
+                        icon: Icon(Icons.save_outlined),
+                        label: Text('Salvar alterações'),
+                        onPressed: authService.isLoading ? null : _saveProfile,
                       ),
                     ],
                   ),

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -37,7 +37,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Você precisa aceitar os termos e condições'),
-            backgroundColor: Colors.red,
+            backgroundColor: Theme.of(context).colorScheme.error,
           ),
         );
       }
@@ -62,7 +62,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('Falha no cadastro. Tente novamente mais tarde.'),
-          backgroundColor: Colors.red,
+          backgroundColor: Theme.of(context).colorScheme.error,
         ),
       );
     }
@@ -76,7 +76,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text('Cadastro'),
-        backgroundColor: Colors.brown[700],
       ),
       body: SafeArea(
         child: SingleChildScrollView(
@@ -88,11 +87,9 @@ class _RegisterScreenState extends State<RegisterScreen> {
               children: [
                 Text(
                   'Criar Conta',
-                  style: TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.brown[800],
-                  ),
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
                 ),
                 SizedBox(height: 20),
                 TextFormField(
@@ -240,12 +237,12 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       child: RichText(
                         text: TextSpan(
                           text: 'Eu aceito os ',
-                          style: TextStyle(color: Colors.black54),
+                          style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
                           children: [
                             TextSpan(
                               text: 'Termos e Condições',
                               style: TextStyle(
-                                color: Colors.brown[700],
+                                color: Theme.of(context).colorScheme.primary,
                                 fontWeight: FontWeight.bold,
                               ),
                             ),
@@ -256,23 +253,20 @@ class _RegisterScreenState extends State<RegisterScreen> {
                   ],
                 ),
                 SizedBox(height: 30),
-                ElevatedButton(
+                FilledButton(
                   onPressed: isLoading ? null : _submitForm,
                   child: isLoading
-                      ? CircularProgressIndicator(
-                          valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                      ? SizedBox(
+                          height: 22,
+                          width: 22,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2.5,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              Theme.of(context).colorScheme.onPrimary,
+                            ),
+                          ),
                         )
-                      : Text(
-                          'Cadastrar',
-                          style: TextStyle(fontSize: 16),
-                        ),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.brown[700],
-                    padding: EdgeInsets.symmetric(vertical: 15),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10),
-                    ),
-                  ),
+                      : Text('Cadastrar'),
                 ),
               ],
             ),

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -8,6 +8,7 @@ import '../services/cart_service.dart';
 import '../services/order_service.dart';
 import 'home_screen.dart';
 import 'login_screen.dart';
+import '../theme/app_theme.dart';
 
 class SplashScreen extends StatefulWidget {
   @override
@@ -61,12 +62,11 @@ class _SplashScreenState extends State<SplashScreen> {
         height: double.infinity,
         decoration: BoxDecoration(
           gradient: LinearGradient(
-            begin: Alignment.topCenter,
-            end: Alignment.bottomCenter,
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
             colors: [
-              Colors.brown[800]!,
-              Colors.brown[600]!,
-              Colors.brown[400]!,
+              AppColors.seed,
+              const Color(0xFF7C3F14),
             ],
           ),
         ),
@@ -82,15 +82,15 @@ class _SplashScreenState extends State<SplashScreen> {
                 boxShadow: [
                   BoxShadow(
                     color: Colors.black26,
-                    blurRadius: 10,
-                    offset: Offset(0, 5),
+                    blurRadius: 16,
+                    offset: Offset(0, 6),
                   ),
                 ],
               ),
               child: Icon(
                 Icons.bakery_dining,
-                size: 80,
-                color: Colors.brown[700],
+                size: 72,
+                color: AppColors.seed,
               ),
             ),
             SizedBox(height: 30),
@@ -107,7 +107,7 @@ class _SplashScreenState extends State<SplashScreen> {
               'Seu pão fresquinho na palma da mão',
               style: TextStyle(
                 fontSize: 16,
-                color: Colors.white70,
+                color: Colors.white.withOpacity(0.85),
               ),
             ),
             SizedBox(height: 50),

--- a/lib/screens/subscription_plans_list_screen.dart
+++ b/lib/screens/subscription_plans_list_screen.dart
@@ -7,6 +7,7 @@ import '../models/subscription_template.dart';
 import '../models/subscription_plan.dart';
 import 'plan_details_screen.dart';
 import 'plans_screen.dart';
+import '../theme/app_theme.dart';
 
 class SubscriptionPlansListScreen extends StatefulWidget {
   const SubscriptionPlansListScreen({super.key});
@@ -38,18 +39,15 @@ class _SubscriptionPlansListScreenState extends State<SubscriptionPlansListScree
     return Scaffold(
       appBar: AppBar(
         title: const Text('Planos de Assinatura'),
-        backgroundColor: Colors.brown,
         actions: [
-          TextButton(
+          TextButton.icon(
             onPressed: () {
               Navigator.of(context).push(
                 MaterialPageRoute(builder: (_) => PlansScreen()),
               );
             },
-            child: const Text(
-              'Criar',
-              style: TextStyle(color: Colors.white),
-            ),
+            icon: const Icon(Icons.add, size: 18),
+            label: const Text('Criar'),
           ),
         ],
       ),
@@ -61,14 +59,14 @@ class _SubscriptionPlansListScreenState extends State<SubscriptionPlansListScree
             style: TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,
-              color: Colors.brown[800],
+              color: Theme.of(context).colorScheme.onSurface,
             ),
           ),
           const SizedBox(height: 8),
           if (subscriptionService.isLoading)
             const Center(child: CircularProgressIndicator())
           else if (templates.isEmpty)
-            Text('Nenhum plano disponível no momento.', style: TextStyle(color: Colors.grey[600]))
+            Text('Nenhum plano disponível no momento.', style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant))
           else
             SizedBox(
               height: 210,
@@ -91,12 +89,12 @@ class _SubscriptionPlansListScreenState extends State<SubscriptionPlansListScree
                 style: TextStyle(
                   fontSize: 18,
                   fontWeight: FontWeight.bold,
-                  color: Colors.brown[800],
+                  color: Theme.of(context).colorScheme.onSurface,
                 ),
               ),
               Text(
                 '${myPlans.length}',
-                style: TextStyle(color: Colors.grey[700]),
+                style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
               ),
             ],
           ),
@@ -115,13 +113,12 @@ class _SubscriptionPlansListScreenState extends State<SubscriptionPlansListScree
                     const SizedBox(height: 6),
                     const Text('Crie um plano para receber entregas recorrentes.'),
                     const SizedBox(height: 12),
-                    ElevatedButton(
+                    FilledButton(
                       onPressed: () {
                         Navigator.of(context).push(
                           MaterialPageRoute(builder: (_) => PlansScreen()),
                         );
                       },
-                      style: ElevatedButton.styleFrom(backgroundColor: Colors.brown),
                       child: const Text('Criar plano'),
                     ),
                   ],
@@ -143,13 +140,12 @@ class _TemplateCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return SizedBox(
       width: 180,
       child: Card(
-        elevation: 3,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         child: InkWell(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(AppRadii.md),
           onTap: () {
             Navigator.of(context).push(
               MaterialPageRoute(builder: (_) => PlansScreen(initialTemplateId: template.id)),
@@ -165,7 +161,7 @@ class _TemplateCard extends StatelessWidget {
                     borderRadius: BorderRadius.circular(10),
                     child: template.imagePath.startsWith('assets/')
                         ? Image.asset(template.imagePath, fit: BoxFit.cover, width: double.infinity)
-                        : Container(color: Colors.brown[50]),
+                        : Container(color: colorScheme.surfaceContainerHighest),
                   ),
                 ),
                 const SizedBox(height: 10),
@@ -180,13 +176,13 @@ class _TemplateCard extends StatelessWidget {
                   template.description,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
-                  style: TextStyle(color: Colors.grey[700], fontSize: 12),
+                  style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
                 ),
                 const SizedBox(height: 6),
                 Text(
                   '${template.products.length} produtos disponíveis',
                   style: TextStyle(
-                    color: Colors.brown[700],
+                    color: colorScheme.primary,
                     fontWeight: FontWeight.bold,
                     fontSize: 12,
                   ),

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+
+/// Tema centralizado do app — Material 3, semente âmbar/caramelo com
+/// superfícies neutras e limpas (estilo apps de delivery modernos).
+///
+/// Use os tokens de [AppColors] apenas para estados semânticos que o
+/// [ColorScheme] não cobre (sucesso, aviso). Para o resto, prefira sempre
+/// `Theme.of(context).colorScheme.*` para manter a consistência.
+class AppColors {
+  AppColors._();
+
+  /// Cor-semente da marca (caramelo tostado). Gera toda a paleta M3.
+  static const Color seed = Color(0xFFB5651D);
+
+  /// Estados semânticos (fora do ColorScheme padrão do M3).
+  static const Color success = Color(0xFF2E7D32);
+  static const Color successContainer = Color(0xFFDCF3DD);
+  static const Color warning = Color(0xFFB26A00);
+  static const Color warningContainer = Color(0xFFFDECCB);
+}
+
+class AppRadii {
+  AppRadii._();
+  static const double sm = 10;
+  static const double md = 14;
+  static const double lg = 20;
+}
+
+class AppTheme {
+  AppTheme._();
+
+  static ThemeData get light {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: AppColors.seed,
+      brightness: Brightness.light,
+    ).copyWith(
+      // Fundo neutro e claro em vez do creme carregado — visual mais "clean".
+      surface: const Color(0xFFFDFCFB),
+    );
+
+    final base = ThemeData(
+      useMaterial3: true,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: const Color(0xFFF7F5F3),
+      fontFamily: 'Roboto',
+    );
+
+    return base.copyWith(
+      // --- AppBar: superfície clara, sem o marrom pesado ---
+      appBarTheme: AppBarTheme(
+        backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
+        elevation: 0,
+        scrolledUnderElevation: 2,
+        surfaceTintColor: colorScheme.surfaceTint,
+        centerTitle: false,
+        titleTextStyle: TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w700,
+          color: colorScheme.onSurface,
+        ),
+      ),
+
+      // --- Cards: elevação sutil e cantos consistentes ---
+      cardTheme: CardTheme(
+        elevation: 0,
+        color: colorScheme.surface,
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.md),
+          side: BorderSide(color: colorScheme.outlineVariant.withOpacity(0.5)),
+        ),
+        clipBehavior: Clip.antiAlias,
+        margin: EdgeInsets.zero,
+      ),
+
+      // --- Botões preenchidos (ação primária) ---
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          minimumSize: const Size.fromHeight(52),
+          textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadii.sm),
+          ),
+        ),
+      ),
+
+      // --- ElevatedButton alinhado ao estilo preenchido (evita brancos lavados) ---
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: colorScheme.primary,
+          foregroundColor: colorScheme.onPrimary,
+          disabledBackgroundColor: colorScheme.onSurface.withOpacity(0.12),
+          disabledForegroundColor: colorScheme.onSurface.withOpacity(0.38),
+          elevation: 0,
+          minimumSize: const Size.fromHeight(52),
+          textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadii.sm),
+          ),
+        ),
+      ),
+
+      // --- Botões contornados (ação secundária) ---
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: colorScheme.primary,
+          minimumSize: const Size.fromHeight(52),
+          side: BorderSide(color: colorScheme.outline),
+          textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppRadii.sm),
+          ),
+        ),
+      ),
+
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(foregroundColor: colorScheme.primary),
+      ),
+
+      // --- Campos de formulário: preenchidos, cantos suaves, foco claro ---
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: colorScheme.surfaceContainerHighest.withOpacity(0.4),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadii.sm),
+          borderSide: BorderSide(color: colorScheme.outlineVariant),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadii.sm),
+          borderSide: BorderSide(color: colorScheme.outlineVariant),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppRadii.sm),
+          borderSide: BorderSide(color: colorScheme.primary, width: 2),
+        ),
+        prefixIconColor: colorScheme.onSurfaceVariant,
+        suffixIconColor: colorScheme.onSurfaceVariant,
+      ),
+
+      // --- Chips de filtro ---
+      chipTheme: ChipThemeData(
+        backgroundColor: colorScheme.surfaceContainerHighest.withOpacity(0.5),
+        selectedColor: colorScheme.primaryContainer,
+        checkmarkColor: colorScheme.onPrimaryContainer,
+        labelStyle: TextStyle(color: colorScheme.onSurfaceVariant, fontWeight: FontWeight.w500),
+        secondaryLabelStyle: TextStyle(color: colorScheme.onPrimaryContainer, fontWeight: FontWeight.w600),
+        side: BorderSide(color: colorScheme.outlineVariant.withOpacity(0.6)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
+      ),
+
+      // --- Navegação inferior (M3 NavigationBar) ---
+      navigationBarTheme: NavigationBarThemeData(
+        backgroundColor: colorScheme.surface,
+        indicatorColor: colorScheme.primaryContainer,
+        elevation: 3,
+        labelTextStyle: WidgetStateProperty.resolveWith((states) {
+          final selected = states.contains(WidgetState.selected);
+          return TextStyle(
+            fontSize: 12,
+            fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+            color: selected ? colorScheme.onSurface : colorScheme.onSurfaceVariant,
+          );
+        }),
+        iconTheme: WidgetStateProperty.resolveWith((states) {
+          final selected = states.contains(WidgetState.selected);
+          return IconThemeData(
+            color: selected ? colorScheme.onPrimaryContainer : colorScheme.onSurfaceVariant,
+          );
+        }),
+      ),
+
+      // --- SnackBar flutuante e arredondado ---
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppRadii.sm)),
+        insetPadding: const EdgeInsets.all(16),
+      ),
+
+      dividerTheme: DividerThemeData(
+        color: colorScheme.outlineVariant.withOpacity(0.6),
+        thickness: 1,
+        space: 1,
+      ),
+
+      // --- Tipografia com pesos mais expressivos ---
+      textTheme: base.textTheme.copyWith(
+        headlineSmall: base.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
+        titleLarge: base.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+        titleMedium: base.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Cria lib/theme/app_theme.dart com ColorScheme.fromSeed (semente ambar/caramelo) e superficies neutras, substituindo o tema inline Material 2 marrom do main.dart. Padroniza AppBar, Card, botoes, inputs, chips, NavigationBar e SnackBar via tema.

Propaga o tema para todas as 15 telas: remove cores cravadas (Colors.brown, grey, etc), migra a navegacao inferior para NavigationBar M3 com Badge nativo, e corrige o bug dos botoes com backgroundColor Colors.white30 (translucidos) em pontos criticos: Finalizar Compra, Finalizar Pedido, Ver Produtos e Planos.

Cores semanticas (status de pedido, fidelidade, sucesso/erro/aviso) preservadas via tokens AppColors e colorScheme.error.